### PR TITLE
BUGFIX: listens for updates to editorRef.current so the LSP server can be reloaded on HMR updates

### DIFF
--- a/apps/embers/package.json
+++ b/apps/embers/package.json
@@ -26,7 +26,7 @@
     "@codemirror/commands": "^6.8.1",
     "@codemirror/state": "^6.5.2",
     "@f1r3fly-io/embers-client-sdk": "workspace:*",
-    "@f1r3fly-io/lightning-bug": "0.7.5",
+    "@f1r3fly-io/lightning-bug": "0.7.6",
     "@f1r3fly-io/tree-sitter-rholang-js-with-comments": "1.1.9",
     "@fortawesome/fontawesome-free": "^7.0.1",
     "@scure/base": "^2.0.0",

--- a/apps/embers/src/pages/EditAgent/EditAgent.tsx
+++ b/apps/embers/src/pages/EditAgent/EditAgent.tsx
@@ -53,7 +53,7 @@ export default function CodeEditor() {
       });
       return () => subscription.unsubscribe();
     }
-  }, []);
+  }, [editorRef.current]);
 
   // Handle Vite HMR updates: HMR unloads the Editor component which triggers
   // its clean-up logic. The clean-up logic consists of shutting down
@@ -71,9 +71,7 @@ export default function CodeEditor() {
       const hmr = import.meta.hot;
       const handleBeforeUpdate = () => editorRef.current?.shutdownLsp();
       hmr.on("vite:beforeUpdate", handleBeforeUpdate);
-      return () => {
-        hmr.off("vite:beforeUpdate", handleBeforeUpdate);
-      };
+      return () => hmr.off("vite:beforeUpdate", handleBeforeUpdate);
     }
   }, []);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/client
       '@f1r3fly-io/lightning-bug':
-        specifier: 0.7.5
-        version: 0.7.5(@popperjs/core@2.11.8)
+        specifier: 0.7.6
+        version: 0.7.6(@popperjs/core@2.11.8)
       '@f1r3fly-io/tree-sitter-rholang-js-with-comments':
         specifier: 1.1.9
         version: 1.1.9
@@ -450,8 +450,8 @@ packages:
   '@codemirror/language@6.11.3':
     resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
 
-  '@codemirror/lint@6.8.5':
-    resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
+  '@codemirror/lint@6.9.0':
+    resolution: {integrity: sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==}
 
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
@@ -771,8 +771,8 @@ packages:
   '@f1r3fly-io/graphl-parser@0.0.19':
     resolution: {integrity: sha512-ekfHQbalKQ5Nqt63FQwkuUXJFK1euCGoCCSHVq9YxQKLozcRZSAo8knccSBT0/v58Ry7xalhbCHoSlHbhazFbQ==, tarball: https://npm.pkg.github.com/download/@f1r3fly-io/graphl-parser/0.0.19/c06858df12d664d3c9f98b8a49b5555cddcce448}
 
-  '@f1r3fly-io/lightning-bug@0.7.5':
-    resolution: {integrity: sha512-RpsYciRGI0tR193myA5Ujmufk7IvQMVX0Trbw2koPd85ElVjaZun0ddQJa7a7iAKRjw0StBf1vD5l1rl/Uo+Qg==, tarball: https://npm.pkg.github.com/download/@f1r3fly-io/lightning-bug/0.7.5/56e71c849129917645da010ba0e1105731c8ce3c}
+  '@f1r3fly-io/lightning-bug@0.7.6':
+    resolution: {integrity: sha512-zYZ8Q9q8jejB+z6mIyb2iyjgvjhXMet0rdypKkvsU943wZxgF5NZstTuRseQIJADSB/oBe9r/H56/aNp8LY1Eg==, tarball: https://npm.pkg.github.com/download/@f1r3fly-io/lightning-bug/0.7.6/458eea4a90b8a363e29353da11ab4c5d8f33b50b}
 
   '@f1r3fly-io/tree-sitter-rholang-js-with-comments@1.1.9':
     resolution: {integrity: sha512-B22b5y7xH1nAu00Y8BCf5jua3IaF3h4yFlJRUj0lujqzAn+JJ0GsCjcsQ1CTOXzXxzXaxqQtZB73JmUB8xYPOw==, tarball: https://npm.pkg.github.com/download/@f1r3fly-io/tree-sitter-rholang-js-with-comments/1.1.9/21459db299fd91bc3300f0cb40a02dab806524d2}
@@ -5708,7 +5708,7 @@ snapshots:
       '@lezer/lr': 1.4.2
       style-mod: 4.1.2
 
-  '@codemirror/lint@6.8.5':
+  '@codemirror/lint@6.9.0':
     dependencies:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.4
@@ -6007,12 +6007,12 @@ snapshots:
 
   '@f1r3fly-io/graphl-parser@0.0.19': {}
 
-  '@f1r3fly-io/lightning-bug@0.7.5(@popperjs/core@2.11.8)':
+  '@f1r3fly-io/lightning-bug@0.7.6(@popperjs/core@2.11.8)':
     dependencies:
       '@codemirror/autocomplete': 6.19.0
       '@codemirror/commands': 6.8.1
       '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.8.5
+      '@codemirror/lint': 6.9.0
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.4


### PR DESCRIPTION
I have only noticed it affects LSP integration (when the `rholang-language-server` is running), but we need to listen for updates to `editorRef.current` in the respective effect handler or the connection to the LSP server is not reloaded correctly on Vite HMR updates.

This PR also bumps the version of Lightning Bug to 0.7.6 which should address the reloading errors.